### PR TITLE
Fix org.freedesktop.DBus.Error.ServiceUnknown errors without polkitd

### DIFF
--- a/slip/dbus/polkit.py
+++ b/slip/dbus/polkit.py
@@ -206,17 +206,17 @@ class PolKit(object):
     @property
     def _interface(self):
         if not PolKit.__interface:
-            PolKit.__interface = dbus.Interface(self._bus.get_object(
-                self._dbus_name, self._dbus_path),
-                self._dbus_interface)
+            try:
+                PolKit.__interface = dbus.Interface(self._bus.get_object(
+                    self._dbus_name, self._dbus_path),
+                    self._dbus_interface)
+            except dbus.DBusException:
+                pass
         return PolKit.__interface
 
     @property
     def _polkit_present(self):
-        try:
-            return bool(self._interface)
-        except dbus.DBusException:
-            return False
+        return bool(self._interface)
 
     def __dbus_system_bus_name_uid(self, system_bus_name):
         bus_object = self._bus.get_object(
@@ -258,7 +258,7 @@ class PolKit(object):
         challenge=True, details={}):
 
         if not self._polkit_present:
-            reply_handler(
+            return reply_handler(
                 action_id is None or
                 self.__dbus_system_bus_name_uid(system_bus_name) == 0)
 


### PR DESCRIPTION
The exception handling for getting the org.freedesktop.PolicyKit1.Authority
interface needs to be done in the _interface property method otherwise this
could lead into unexpected behaviour where self._interface in
_polkit_present is not None if polkit is not present.

If polkit is not present self._interface.CheckAuthorization should not be
called in IsSystemBusNameAuthorizedAsync.

This fixes RHBZ#1393488