### PR TITLE
Python 3.10+ fix: Use collections.abc.Callable instead of collections.Callable

### DIFF
--- a/slip/dbus/polkit.py
+++ b/slip/dbus/polkit.py
@@ -26,7 +26,7 @@ PolicyKit with dbus services and clients."""
 
 from __future__ import absolute_import
 
-import collections
+import collections.abc
 import dbus
 from decorator import decorator
 from functools import reduce
@@ -103,14 +103,14 @@ def enable_proxy(
             def some_method(self, ...):
                 ..."""
 
-    assert(func is None or isinstance(func, collections.Callable))
+    assert(func is None or isinstance(func, collections.abc.Callable))
 
     assert(
         authfail_result in (None, AUTHFAIL_DONTCATCH) or
         authfail_exception is None)
     assert(
         authfail_callback is None or
-        isinstance(authfail_callback, collections.Callable))
+        isinstance(authfail_callback, collections.abc.Callable))
     assert(
         authfail_exception is None or
         issubclass(authfail_exception, Exception))

--- a/slip/util/hookable.py
+++ b/slip/util/hookable.py
@@ -23,7 +23,7 @@
 """This module contains variants of certain base types which call registered
 hooks on changes."""
 
-import collections
+import collections.abc
 from six import with_metaclass
 
 __all__ = ["Hookable", "HookableSet"]
@@ -67,7 +67,7 @@ class _HookEntry(object):
 
     def __init__(self, hook, args, kwargs, hookable=None):
 
-        assert(isinstance(hook, collections.Callable))
+        assert(isinstance(hook, collections.abc.Callable))
         assert(isinstance(hookable, Hookable))
 
         for n, x in enumerate(args):
@@ -174,7 +174,7 @@ class Hookable(with_metaclass(HookableType, object)):
         self.__add_hook(hook, self, *args, **kwargs)
 
     def __add_hook(self, hook, _hookable, *args, **kwargs):
-        assert isinstance(hook, collections.Callable)
+        assert isinstance(hook, collections.abc.Callable)
         assert isinstance(_hookable, Hookable)
         hookentry = _HookEntry(hook, args, kwargs, hookable=_hookable)
         self.__hooks__.add(hookentry)


### PR DESCRIPTION
The deprecated aliases to Collections Abstract Base Classes were removed from
the collections module in Python 3.10.
https://docs.python.org/3.10/whatsnew/changelog.html#python-3-10-0-alpha-5
https://bugs.python.org/issue37324