### PR TITLE
use setuptools instead of distutils (dropped in Python 3.12)

### DIFF
--- a/python-slip.spec
+++ b/python-slip.spec
@@ -13,6 +13,8 @@ BuildRequires:  python
 BuildRequires:  python-devel
 BuildRequires:  python3
 BuildRequires:  python3-devel
+BuildRequires:  python-setuptools
+BuildRequires:  python3-setuptools
 
 Requires:   libselinux-python
 Requires:   python-six

--- a/setup.py.in
+++ b/setup.py.in
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="slip", version="@VERSION@",
         py_modules=["slip.__init__", "slip.util.__init__",


### PR DESCRIPTION
First: thank you for this amazing piece of code! Years old and still works even with modern Python.

I think this little change is enough to make it work even with Python 3.12 (it really felt like sacrilege to touch such ancient package), we'll see what happens when we try to build non-Python packages on Python 3.12.

Again, thank you, you really made my day as a packager! :+1: :100: :heart: 